### PR TITLE
Fixes mailbox

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.vlingo</groupId>
   <artifactId>vlingo-telemetry</artifactId>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <name>vlingo-telemetry</name>
   <description>The reactive metrics collector plugin for the vlingo/platform, including support for vlingo/actors, vlingo/http, vlingo/lattice, vlingo/streams, and others.</description>
   <url>https://github.com/vlingo/vlingo-telemetry</url>

--- a/src/main/java/io/vlingo/telemetry/plugin/mailbox/DefaultMailboxTelemetry.java
+++ b/src/main/java/io/vlingo/telemetry/plugin/mailbox/DefaultMailboxTelemetry.java
@@ -7,7 +7,7 @@
 
 package io.vlingo.telemetry.plugin.mailbox;
 
-import io.vlingo.actors.Message;
+import io.vlingo.actors.Actor;
 import io.vlingo.telemetry.Telemetry;
 
 public class DefaultMailboxTelemetry implements MailboxTelemetry {
@@ -28,16 +28,16 @@ public class DefaultMailboxTelemetry implements MailboxTelemetry {
   }
 
   @Override
-  public void onSendMessage(final Message message) {
-    incrementGaugeFor(message, 1, PENDING);
+  public void onSendMessage(final Actor actor) {
+    incrementGaugeFor(actor, 1, PENDING);
   }
 
   @Override
-  public void onSendMessageFailed(final Message message, final Throwable exception) {
+  public void onSendMessageFailed(final Actor actor, final Throwable exception) {
     Class<? extends Throwable> exceptionClass = exception.getClass();
     String exceptionName = exceptionClass.getSimpleName();
 
-    incrementCounterFor(message, FAILED_SEND + "." + exceptionName);
+    incrementCounterFor(actor, FAILED_SEND + "." + exceptionName);
     incrementCounterFor(exceptionClass);
   }
 
@@ -47,8 +47,8 @@ public class DefaultMailboxTelemetry implements MailboxTelemetry {
   }
 
   @Override
-  public void onReceiveMessage(final Message message) {
-    incrementGaugeFor(message, -1, PENDING);
+  public void onReceiveMessage(final Actor actor) {
+    incrementGaugeFor(actor, -1, PENDING);
   }
 
   @Override
@@ -57,22 +57,22 @@ public class DefaultMailboxTelemetry implements MailboxTelemetry {
   }
 
   @Override
-  public void onDeliverMessageFailed(final Message message, final Throwable exception) {
+  public void onDeliverMessageFailed(final Actor actor, final Throwable exception) {
     Class<? extends Throwable> exceptionClass = exception.getClass();
     String exceptionName = exceptionClass.getSimpleName();
 
-    incrementCounterFor(message, FAILED_DELIVER + "." + exceptionName);
+    incrementCounterFor(actor, FAILED_DELIVER + "." + exceptionName);
     incrementCounterFor(exceptionClass);
   }
 
-  public final void incrementGaugeFor(final Message message, final int delta, final String concept) {
-    String gaugeName = PREFIX + message.actor().getClass().getSimpleName() + "." + concept;
-    telemetry.gauge(gaugeName, delta, Telemetry.Tag.of("Address", message.actor().address().name()));
+  public final void incrementGaugeFor(final Actor actor, final int delta, final String concept) {
+    String gaugeName = PREFIX + actor.getClass().getSimpleName() + "." + concept;
+    telemetry.gauge(gaugeName, delta, Telemetry.Tag.of("Address", actor.address().name()));
   }
 
-  public final void incrementCounterFor(final Message message, final String concept) {
-    String gaugeName = PREFIX + message.actor().getClass().getSimpleName() + "." + concept;
-    telemetry.count(gaugeName, 1, Telemetry.Tag.of("Address", message.actor().address().name()));
+  public final void incrementCounterFor(final Actor actor, final String concept) {
+    String gaugeName = PREFIX + actor.getClass().getSimpleName() + "." + concept;
+    telemetry.count(gaugeName, 1, Telemetry.Tag.of("Address", actor.address().name()));
   }
 
   public final void incrementCounterFor(final Class<? extends Throwable> ex) {

--- a/src/main/java/io/vlingo/telemetry/plugin/mailbox/MailboxTelemetry.java
+++ b/src/main/java/io/vlingo/telemetry/plugin/mailbox/MailboxTelemetry.java
@@ -7,14 +7,14 @@
 
 package io.vlingo.telemetry.plugin.mailbox;
 
-import io.vlingo.actors.Message;
+import io.vlingo.actors.Actor;
 
 public interface MailboxTelemetry {
-  void onSendMessage(final Message message);
-  void onSendMessageFailed(final Message message, final Throwable exception);
+  void onSendMessage(final Actor actor);
+  void onSendMessageFailed(final Actor actor, final Throwable exception);
 
   void onReceiveEmptyMailbox();
-  void onReceiveMessage(final Message message);
+  void onReceiveMessage(final Actor actor);
   void onReceiveMessageFailed(final Throwable exception);
-  void onDeliverMessageFailed(final Message message, final Throwable exception);
+  void onDeliverMessageFailed(final Actor actor, final Throwable exception);
 }

--- a/src/main/java/io/vlingo/telemetry/plugin/mailbox/TelemetryMailbox.java
+++ b/src/main/java/io/vlingo/telemetry/plugin/mailbox/TelemetryMailbox.java
@@ -64,7 +64,7 @@ public class TelemetryMailbox implements Mailbox {
   }
 
   @Override
-  public void send(Actor actor, Class<?> protocol, Consumer<?> consumer, Returns<?> returns, String representation) {
+  public <T> void send(Actor actor, Class<T> protocol, Consumer<T> consumer, Returns<?> returns, String representation) {
     try {
       delegate.send(actor, protocol, consumer, returns, representation);
       telemetry.onSendMessage(actor);

--- a/src/main/java/io/vlingo/telemetry/plugin/mailbox/TelemetryMailbox.java
+++ b/src/main/java/io/vlingo/telemetry/plugin/mailbox/TelemetryMailbox.java
@@ -64,7 +64,7 @@ public class TelemetryMailbox implements Mailbox {
   }
 
   @Override
-  public <T> void send(Actor actor, Class<T> protocol, Consumer<T> consumer, Returns<?> returns, String representation) {
+  public void send(Actor actor, Class<?> protocol, Consumer<?> consumer, Returns<?> returns, String representation) {
     try {
       delegate.send(actor, protocol, consumer, returns, representation);
       telemetry.onSendMessage(actor);

--- a/src/main/java/io/vlingo/telemetry/plugin/mailbox/TelemetryMessage.java
+++ b/src/main/java/io/vlingo/telemetry/plugin/mailbox/TelemetryMessage.java
@@ -31,9 +31,9 @@ public class TelemetryMessage implements Message {
   public void deliver() {
     try {
       delegate.deliver();
-      telemetry.onReceiveMessage(delegate);
+      telemetry.onReceiveMessage(delegate.actor());
     } catch (RuntimeException ex) {
-      telemetry.onDeliverMessageFailed(delegate, ex);
+      telemetry.onDeliverMessageFailed(delegate.actor(), ex);
     }
   }
 

--- a/src/test/java/io/vlingo/telemetry/plugin/mailbox/DefaultMailboxTelemetryTest.java
+++ b/src/test/java/io/vlingo/telemetry/plugin/mailbox/DefaultMailboxTelemetryTest.java
@@ -56,10 +56,10 @@ public class DefaultMailboxTelemetryTest extends ActorsTest {
 
   @Test
   public void testThatSendAndReceiveRegistersACounterOnTheActorsMailbox() {
-    telemetry.onSendMessage(message);
+    telemetry.onSendMessage(message.actor());
     assertPendingMessagesNumberIs(1);
 
-    telemetry.onReceiveMessage(message);
+    telemetry.onReceiveMessage(message.actor());
     assertPendingMessagesNumberIs(0);
   }
 
@@ -71,7 +71,7 @@ public class DefaultMailboxTelemetryTest extends ActorsTest {
 
   @Test
   public void testThatFailedSentsAreCounted() {
-    telemetry.onSendMessageFailed(message, expectedException());
+    telemetry.onSendMessageFailed(message.actor(), expectedException());
     assertFailuresAre(1, DefaultMailboxTelemetry.FAILED_SEND);
     assertIllegalStateExceptionCount(1);
   }
@@ -84,7 +84,7 @@ public class DefaultMailboxTelemetryTest extends ActorsTest {
 
   @Test
   public void testThatDeliveringFailuresAreCountedFromMessage() {
-    telemetry.onDeliverMessageFailed(message, expectedException());
+    telemetry.onDeliverMessageFailed(message.actor(), expectedException());
 
     assertFailuresAre(1, DefaultMailboxTelemetry.FAILED_DELIVER);
     assertIllegalStateExceptionCount(1);

--- a/src/test/java/io/vlingo/telemetry/plugin/mailbox/TelemetryMailboxTest.java
+++ b/src/test/java/io/vlingo/telemetry/plugin/mailbox/TelemetryMailboxTest.java
@@ -73,7 +73,7 @@ public class TelemetryMailboxTest {
     Message notNullMessage = telemetryMailbox.receive();
 
     verify(delegate).receive();
-    verify(telemetry).onReceiveMessage(message);
+    verify(telemetry).onReceiveMessage(message.actor());
     verify(telemetry, never()).onReceiveEmptyMailbox();
 
     assertEquals(message, notNullMessage);

--- a/src/test/java/io/vlingo/telemetry/plugin/mailbox/TelemetryMessageTest.java
+++ b/src/test/java/io/vlingo/telemetry/plugin/mailbox/TelemetryMessageTest.java
@@ -47,7 +47,7 @@ public class TelemetryMessageTest {
     telemetryMessage.deliver();
 
     verify(delegate).deliver();
-    verify(telemetry).onReceiveMessage(delegate);
+    verify(telemetry).onReceiveMessage(delegate.actor());
   }
 
   @Test
@@ -58,8 +58,8 @@ public class TelemetryMessageTest {
     telemetryMessage.deliver();
 
     verify(delegate).deliver();
-    verify(telemetry, never()).onReceiveMessage(delegate);
-    verify(telemetry).onDeliverMessageFailed(delegate, exception);
+    verify(telemetry, never()).onReceiveMessage(delegate.actor());
+    verify(telemetry).onDeliverMessageFailed(delegate.actor(), exception);
   }
 
   @Test


### PR DESCRIPTION
The `TelemetryMailbox` would throw when `TelemetryMailbox#delegate` is preallocated.